### PR TITLE
Make formatting work with diff as well

### DIFF
--- a/src/format-output.ts
+++ b/src/format-output.ts
@@ -1,4 +1,7 @@
-const colors = {
+import { labelTransient } from './transients.ts'
+import type { AttributeLiteral } from './transients.ts'
+
+const control = {
   red: '\x1b[31m',
   green: '\x1b[32m',
   yellow: '\x1b[33m',
@@ -8,95 +11,45 @@ const colors = {
   white: '\x1b[37m',
   reset: '\x1b[0m',
   bold: '\x1b[1m',
-  col: '\x1b[24G'  // Align values to col 24
+  col: '\x1b[25G'  // Align values to col 25
 }
 
-interface Form {
-    hitpoints: { // Hit points are outputted in their own section as key value pairs
-        Total: number;
-        Legs: number;
-        Abdomen: number;
-        Chest: number;
-        Arms: number;
-        Head: number;
-    }
-    modifiers: { // modifiers are outputted in separate section as key-value pairs
-        Agility: string | number;
-        Communication: string | number;
-        Knowledge: string | number;
-        Magic: string | number;
-        Manipulation: string | number;
-        Perception: string | number;
-        Stealh: string | number;
-    }
-    // rest of the properties are outputted as key-value pairs line by line
-    healingrate: number;
-    dexsr: number;
-    strsr: number;
-    damagebonus: string;
-    spiritcombatdamage: string;
-    magicpoints: number; 
+const formatSection = (label: string, partial: Record<AttributeLiteral, unknown>) => {
+    const actual = Object.entries(partial)
+      .filter(([_, value]) => value !== undefined)
+    return actual.length > 0
+      ? [
+            `${control.bold}${label}:${control.reset}`,
+            ...actual.map(([key, value]) => `  ${labelTransient(key)}:${control.col}${value}`)
+        ].join('\n') + '\n'
+      : ''
 }
 
-export const formatOutput = (transients: Record<string, number | string>): string => {
-    // Create Form data structure from transients
-    const formData: Form = {
-        hitpoints: {
-            Total: transients.hitPoints as number,
-            Head: transients.head as number,
-            Arms: transients.arms as number,   
-            Chest: transients.chest as number,
-            Abdomen: transients.abdomen as number,
-            Legs: transients.legs as number,
-        },
-        modifiers: {
-            Agility: transients.agilitySkillModifier,
-            Communication: transients.communicationSkillModifier,
-            Knowledge: transients.knowledgeSkillModifier,
-            Magic: transients.magicSkillModifier,
-            Manipulation: transients.manipulationSkillModifier,
-            Perception: transients.perceptionSkillModifier,
-            Stealh: transients.stealthSkillModifier,
-        },
-        healingrate: transients.healingRate as number,
-        dexsr: transients.dexStrikeRank as number,
-        strsr: transients.sizStrikeRank as number,
-        damagebonus: transients.damageBonus as string,
-        spiritcombatdamage: transients.spiritCombatDamage as string,
-        magicpoints: transients.magicPoints as number,
-    }
+export const formatOutput = (transients: Record<AttributeLiteral, number | string>): string =>
+  formatSection("Hit Points", {
+      hitPoints: transients.hitPoints,
+      head: transients.head,
+      arms: transients.arms,
+      chest: transients.chest,
+      abdomen: transients.abdomen,
+      legs: transients.legs
+  } as Record<AttributeLiteral, number | string>) +
 
-    // Format hit points section
-    const hitPointsSection = [
-        `${colors.bold}Hit Points:${colors.reset}`,
-        ...Object.entries(formData.hitpoints)
-            .map(([key, value]) => `  ${key}:${colors.col}${value}`)
-    ].join('\n')
+  formatSection('Skill Modifiers', {
+      agilitySkillModifier: transients.agilitySkillModifier,
+      communicationSkillModifier: transients.communicationSkillModifier,
+      knowledgeSkillModifier: transients.knowledgeSkillModifier,
+      magicSkillModifier: transients.magicSkillModifier,
+      manipulationSkillModifier: transients.manipulationSkillModifier,
+      perceptionSkillModifier: transients.perceptionSkillModifier,
+      stealthSkillModifier: transients.stealthSkillModifier
+  } as Record<AttributeLiteral, number | string>) +
 
-    // Format modifiers section
-    const modifiersSection = [
-        `${colors.bold}Skill Modifiers:${colors.reset}`,
-        ...Object.entries(formData.modifiers)
-            .map(([key, value]) => `  ${key}:${colors.col}${value}`)
-    ].join('\n')
-
-    // Format individual properties
-    const individualProperties = [
-        `Healing rate:${colors.col}${formData.healingrate}`,
-        `DEX strike rank:${colors.col}${formData.dexsr}`,
-        `SIZ strike rank:${colors.col}${formData.strsr}`,
-        `Damage bonus:${colors.col}${formData.damagebonus}`,
-        `Spirit combat damage:${colors.col}${formData.spiritcombatdamage}`,
-        `Magic points:${colors.col}${formData.magicpoints}`,
-    ].join('\n')
-
-    // Combine all sections with spaces between them
-    return [
-        hitPointsSection,
-        '',
-        modifiersSection,
-        '',
-        individualProperties
-    ].join('\n')
-}
-
+  formatSection("Other", {
+      healingRate: transients.healingRate,
+      dexStrikeRank: transients.dexStrikeRank,
+      sizStrikeRank: transients.sizStrikeRank,
+      damageBonus: transients.damageBonus,
+      spiritCombatDamage: transients.spiritCombatDamage,
+      magicPoints: transients.magicPoints
+  } as Record<AttributeLiteral, number | string>)

--- a/src/format-output.ts
+++ b/src/format-output.ts
@@ -14,7 +14,7 @@ const control = {
   col: '\x1b[25G'  // Align values to col 25
 }
 
-const formatSection = (label: string, partial: Record<AttributeLiteral, unknown>) => {
+const formatSection = (label: string, partial: Partial<Record<AttributeLiteral, unknown>>) => {
     const actual = Object.entries(partial)
       .filter(([_, value]) => value !== undefined)
     return actual.length > 0
@@ -33,8 +33,7 @@ export const formatOutput = (transients: Record<AttributeLiteral, number | strin
       chest: transients.chest,
       abdomen: transients.abdomen,
       legs: transients.legs
-  } as Record<AttributeLiteral, number | string>) +
-
+  }) +
   formatSection('Skill Modifiers', {
       agilitySkillModifier: transients.agilitySkillModifier,
       communicationSkillModifier: transients.communicationSkillModifier,
@@ -43,8 +42,7 @@ export const formatOutput = (transients: Record<AttributeLiteral, number | strin
       manipulationSkillModifier: transients.manipulationSkillModifier,
       perceptionSkillModifier: transients.perceptionSkillModifier,
       stealthSkillModifier: transients.stealthSkillModifier
-  } as Record<AttributeLiteral, number | string>) +
-
+  }) +
   formatSection("Other", {
       healingRate: transients.healingRate,
       dexStrikeRank: transients.dexStrikeRank,
@@ -52,4 +50,4 @@ export const formatOutput = (transients: Record<AttributeLiteral, number | strin
       damageBonus: transients.damageBonus,
       spiritCombatDamage: transients.spiritCombatDamage,
       magicPoints: transients.magicPoints
-  } as Record<AttributeLiteral, number | string>)
+  })

--- a/src/format-output.ts
+++ b/src/format-output.ts
@@ -25,7 +25,7 @@ const formatSection = (label: string, partial: Partial<Record<AttributeLiteral, 
       : ''
 }
 
-export const formatOutput = (transients: Record<AttributeLiteral, number | string>): string =>
+export const formatOutput = (transients: Record<AttributeLiteral, unknown>): string =>
   formatSection("Hit Points", {
       hitPoints: transients.hitPoints,
       head: transients.head,

--- a/src/format-transients.ts
+++ b/src/format-transients.ts
@@ -1,17 +1,14 @@
 import { labelTransient } from './transients.ts'
+import type { AttributeLiteral } from './transients.ts'
 
 export const formatDiff = (
-  currentTransients: Record<string, number | string>,
-  newTransients: Record<string, number | string>
-): string[] =>
+  currentTransients: Record<AttributeLiteral, number | string>,
+  newTransients: Record<AttributeLiteral, number | string>
+) =>
   Object.entries(currentTransients)
-    .reduce<string[]>((acc, [currentKey, currentValue]) => {
-      const maybeNewValue = newTransients[currentKey]
+    .reduce((acc, [currentKey, currentValue]) => {
+      const maybeNewValue = newTransients[currentKey as AttributeLiteral]
       return (maybeNewValue !== undefined && maybeNewValue !== currentValue)
-        ? [...acc, `${labelTransient(currentKey)}: ${currentValue} → ${maybeNewValue}`]
+        ? { ...acc, [currentKey]: `${currentValue} → ${maybeNewValue}` }
         : acc
-    }, [])
-
-export const formatTransients = (currentTransients: Record<string, number | string>) =>
-  Object.entries(currentTransients)
-    .map(([key, value]) => `${labelTransient(key)}: ${value}`)
+    }, {} as Record<AttributeLiteral, string>)

--- a/src/format-transients.ts
+++ b/src/format-transients.ts
@@ -1,4 +1,3 @@
-import { labelTransient } from './transients.ts'
 import type { AttributeLiteral } from './transients.ts'
 
 export const formatDiff = (

--- a/src/hit-points.ts
+++ b/src/hit-points.ts
@@ -15,7 +15,9 @@ export const calculateTotalHitPoints = (stats: Stats): number => {
   return conMod + sizMod + powMod
 }
 
-const locationsFromBaseValue = (base: number): Record<string, number> => ({
+export type HitLocationLiteral = 'legs' | 'abdomen' | 'chest' | 'arms' | 'head'
+
+const locationsFromBaseValue = (base: number): Record<HitLocationLiteral, number> => ({
   legs: base + 1,
   abdomen: base + 1,
   chest: base + 2,
@@ -23,7 +25,7 @@ const locationsFromBaseValue = (base: number): Record<string, number> => ({
   head: base + 1
 })
 
-export const calculateLocationHitPoints = (totalHitPoints: number): Record<string, number> => {
+export const calculateLocationHitPoints = (totalHitPoints: number): Record<HitLocationLiteral, number> => {
   const baseValue = totalHitPoints <= 6 ? 1 : Math.floor((totalHitPoints - 1) / 3)
   return locationsFromBaseValue(baseValue)
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,5 +16,10 @@ if (args.length === 0) {
   const newTransients = calculateTransients({ ...currentStats, ...newStats })
   const changes = formatDiff(currentTransients, newTransients)
 
-  console.log(formatOutput(changes))
+  const output = formatOutput(changes)
+  if (output.length === 0) {
+    console.log("No changes\n")
+  } else {
+    console.log(output)
+  }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import { readCurrentStats } from './stats.ts'
 import { argsToPartialStats } from './args.ts'
 import { calculateTransients } from './transients.ts'
-import { formatTransients, formatDiff } from './format-transients.ts'
+import { formatDiff } from './format-transients.ts'
 import { formatOutput } from './format-output.ts'
 
 const currentStats = await readCurrentStats('./.current.json')
@@ -16,9 +16,5 @@ if (args.length === 0) {
   const newTransients = calculateTransients({ ...currentStats, ...newStats })
   const changes = formatDiff(currentTransients, newTransients)
 
-  if (changes.length === 0) {
-    console.log('No changes')
-  } else {
-    changes.forEach(change => console.log(change))
-  }
+  console.log(formatOutput(changes))
 }

--- a/src/skill-modifiers.ts
+++ b/src/skill-modifiers.ts
@@ -20,44 +20,52 @@ const sumAndFormat = (modifiers: number[]) => {
 const minusFiveToFive = [ -5, 0, 0, 0, 5, 5 ] as StatBrackets
 const minusTenToTen = [ -10, -5, 0, 5, 10, 5 ] as StatBrackets
 
+export type SkillModifierLiteral = 'agilitySkillModifier' |
+  'communicationSkillModifier' |
+  'knowledgeSkillModifier' |
+  'magicSkillModifier' |
+  'manipulationSkillModifier' |
+  'perceptionSkillModifier' |
+  'stealthSkillModifier'
+
 // Fun fact: CON is not used in any of these
-export const calculateAllSkillModifiers = ({ str, siz, dex, int, pow, cha }: Stats) =>
-  Object.entries({
-    agilitySkillModifier: [
+export const calculateAllSkillModifiers = (
+  { str, siz, dex, int, pow, cha }: Stats
+): Record<SkillModifierLiteral, string> =>
+  ({
+    agilitySkillModifier: sumAndFormat([
       skillModifier(str, minusFiveToFive),
       skillModifier(siz, [ 5, 0, 0, 0, -5, -5 ]),
       skillModifier(dex, minusTenToTen),
       skillModifier(pow, minusFiveToFive)
-    ],
-    communicationSkillModifier: [
+    ]),
+    communicationSkillModifier: sumAndFormat([
       skillModifier(int, minusFiveToFive),
       skillModifier(pow, minusFiveToFive),
       skillModifier(cha, minusTenToTen),
-    ],
-    knowledgeSkillModifier: [
+    ]),
+    knowledgeSkillModifier: sumAndFormat([
       skillModifier(int, minusTenToTen),
       skillModifier(pow, minusFiveToFive),
-    ],
-    magicSkillModifier: [
+    ]),
+    magicSkillModifier: sumAndFormat([
       skillModifier(pow, minusTenToTen),
       skillModifier(cha, minusFiveToFive)
-    ],
-    manipulationSkillModifier: [
+    ]),
+    manipulationSkillModifier: sumAndFormat([
       skillModifier(str, minusFiveToFive),
       skillModifier(dex, minusTenToTen),
       skillModifier(int, minusTenToTen),
       skillModifier(pow, minusFiveToFive)
-    ],
-    perceptionSkillModifier: [
+    ]),
+    perceptionSkillModifier: sumAndFormat([
       skillModifier(int, minusTenToTen),
       skillModifier(pow, minusFiveToFive)
-    ],
-    stealthSkillModifier: [
+    ]),
+    stealthSkillModifier: sumAndFormat([
       skillModifier(siz, [ 10, 5, 0, -5, -10, -5 ]),
       skillModifier(dex, minusTenToTen),
       skillModifier(int, minusTenToTen),
       skillModifier(pow, [ 5, 0, 0, 0, -5, -5 ])
-    ]
+    ])
   })
-    .map(([ key, values ]) => ({ [key]: sumAndFormat(values) }))
-    .reduce((acc, entry) => ({ ...acc, ...entry }), {})

--- a/src/transients.ts
+++ b/src/transients.ts
@@ -1,41 +1,54 @@
 import type { Stats } from './stats.ts'
 import { calculateLocationHitPoints, calculateTotalHitPoints } from './hit-points.ts'
+import type { HitLocationLiteral } from './hit-points.ts'
 import { calculateHealingRate } from './healing-rate.ts'
 import { calculateDamageBonus } from './damage-bonus.ts'
 import { calculateSpiritCombatDamage } from './spirit-combat-damage.ts'
 import { calculateMaximumEnc } from './maximum-enc.ts'
 import { calculateDexStrikeRank, calculateSizStrikeRank } from './strike-rank.ts'
 import { calculateAllSkillModifiers } from './skill-modifiers.ts'
+import type { SkillModifierLiteral } from './skill-modifiers.ts'
 
-const labels: Record<string, string> = {
+export type AttributeLiteral = 'magicPoints' |
+  'hitPoints' |
+  'healingRate' |
+  'damageBonus' |
+  'spiritCombatDamage' |
+  'maximumEnc' |
+  'dexStrikeRank' |
+  'sizStrikeRank' |
+  HitLocationLiteral |
+  SkillModifierLiteral
+
+const labels: Record<AttributeLiteral, string> = {
   magicPoints: "Magic points",
-  hitPoints: "Hit points, total",
-  legs: "Hit points, legs",
-  abdomen: "Hit points, abdomen",
-  chest: "Hit points: chest",
-  arms: "Hit points, arms",
-  head: "Hit points, head",
+  hitPoints: "Total",
+  legs: "Legs",
+  abdomen: "Abdomen",
+  chest: "Chest",
+  arms: "Arms",
+  head: "Head",
   healingRate: "Healing rate",
   damageBonus: "Damage bonus",
   spiritCombatDamage: "Spirit combat damage",
   maximumEnc: "Maximum ENC",
   dexStrikeRank: "DEX strike rank",
   sizStrikeRank: "SIZ strike rank",
-  agilitySkillModifier: "Agility skills category modifier",
-  communicationSkillModifier: "Communication skills category modifier",
-  knowledgeSkillModifier: "Knowledge skills category modifier",
-  magicSkillModifier: "Magic skills category modifier",
-  manipulationSkillModifier: "Manipulation skills category modifier",
-  perceptionSkillModifier: "Perception skills category modifier",
-  stealthSkillModifier: "Stealth skills category modifier"
+  agilitySkillModifier: "Agility",
+  communicationSkillModifier: "Communication",
+  knowledgeSkillModifier: "Knowledge",
+  magicSkillModifier: "Magic",
+  manipulationSkillModifier: "Manipulation",
+  perceptionSkillModifier: "Perception",
+  stealthSkillModifier: "Stealth"
 }
 
 export const labelTransient = (key: string): string => {
-  const maybeLabel = labels[key]
+  const maybeLabel = labels[key as AttributeLiteral]
   return maybeLabel !== undefined ? maybeLabel : key
 }
 
-export const calculateTransients = (stats: Stats): Record<string, number | string> => ({
+export const calculateTransients = (stats: Stats): Record<AttributeLiteral, number | string> => ({
   magicPoints: stats.pow,
   hitPoints: calculateTotalHitPoints(stats),
   ...calculateLocationHitPoints(calculateTotalHitPoints(stats)),


### PR DESCRIPTION
Tyypitys ei oo vielä ihan kohillaan, siellä on paljon `foo as Bar` tyyppistä julistusta mitä ei pitäis tarttee. Mulla ei oo ihan niin paljon tollasesta Record-tyyppisestä tyypityksestä joten ihan hyvää sormiharjoittelua tää on. Toi miks toi on tollanen record lähti ihan siitä että se default statti-filu on mahdollisimman human readable. 

Nyt tuolla on jonkin verran noita FooLiteral tyyppejä jotka on eri stringien unioneita ja joilla tyypitetään olion mahdolliset kenttien avaimet. Se sitoo yhteen ihan mukavasti esim printattavat nimet ja varsinaisen tietotyypin.

Pitää kans kattoo missä kohtaa ois oikeesti järkevä vaihtaa tyypitys Record<AttributeLiteral, string | number> -> Record<AttributeLiteral, unknown>. Nysse on tuolla ihan lopussa ku generoidaan ulostuutattavia stringejä mutta se vois olla tosi paljon aikaisemminkin, ehkä. Samoin pitäiskö Record<AttributeLiteral, unknown>:lla olla joku type alias, esim AttributeValue tjsp? 